### PR TITLE
Change pin name define to variable

### DIFF
--- a/variants/Seeed_XIAO_nRF52840/variant.h
+++ b/variants/Seeed_XIAO_nRF52840/variant.h
@@ -43,17 +43,17 @@ extern "C"
 #define PIN_BUTTON1          (PINS_COUNT)
 
 //Digital PINs
-#define D0 (0ul)
-#define D1 (1ul)
-#define D2 (2ul)
-#define D3 (3ul)
-#define D4 (4ul)
-#define D5 (5ul)
-#define D6 (6ul)
-#define D7 (7ul)
-#define D8 (8ul)
-#define D9 (9ul)
-#define D10 (10ul)
+static const uint8_t D0  = 0 ;
+static const uint8_t D1  = 1 ;
+static const uint8_t D2  = 2 ;
+static const uint8_t D3  = 3 ;
+static const uint8_t D4  = 4 ;
+static const uint8_t D5  = 5 ;
+static const uint8_t D6  = 6 ;
+static const uint8_t D7  = 7 ;
+static const uint8_t D8  = 8 ;
+static const uint8_t D9  = 9 ;
+static const uint8_t D10 = 10;
 
 /*
  * Analog pins

--- a/variants/Seeed_XIAO_nRF52840_Sense/variant.h
+++ b/variants/Seeed_XIAO_nRF52840_Sense/variant.h
@@ -45,17 +45,17 @@ extern "C"
 #define PIN_BUTTON1          (PINS_COUNT)
 
 //Digital PINs
-#define D0 (0ul)
-#define D1 (1ul)
-#define D2 (2ul)
-#define D3 (3ul)
-#define D4 (4ul)
-#define D5 (5ul)
-#define D6 (6ul)
-#define D7 (7ul)
-#define D8 (8ul)
-#define D9 (9ul)
-#define D10 (10ul)
+static const uint8_t D0  = 0 ;
+static const uint8_t D1  = 1 ;
+static const uint8_t D2  = 2 ;
+static const uint8_t D3  = 3 ;
+static const uint8_t D4  = 4 ;
+static const uint8_t D5  = 5 ;
+static const uint8_t D6  = 6 ;
+static const uint8_t D7  = 7 ;
+static const uint8_t D8  = 8 ;
+static const uint8_t D9  = 9 ;
+static const uint8_t D10 = 10;
 
 /*
  * Analog pins


### PR DESCRIPTION
An error occurred when using ArduinoEigen and this platform.

```
C:\Users\XXXXXXXXXX\AppData\Local\Arduino15\packages\Seeeduino\hardware\nrf52\1.1.1\variants\Seeed_XIAO_nRF52840/variant.h:46:16: error: lvalue required as unary '&' operand
   46 | #define D0 (0ul)
      |                ^
d:\DEVELOP\XXXXXXXXX\Arduino\libraries\ArduinoEigen-master/ArduinoEigen/Eigen/src/Core/products/GeneralBlockPanelKernel.h:1270:73: note: in expansion of macro 'D0'
 1270 |           peeled_kc_onestep(1, blA, blB, traits, &A1, &rhs_panel, &T0, &D0, &D1, &D2, &D3);
      |                                                                         ^~
C:\Users\XXXXXXXXXX\AppData\Local\Arduino15\packages\Seeeduino\hardware\nrf52\1.1.1\variants\Seeed_XIAO_nRF52840/variant.h:47:16: error: lvalue required as unary '&' operand
   47 | #define D1 (1ul)
      |                ^
d:\DEVELOP\XXXXXXXXX\Arduino\libraries\ArduinoEigen-master/ArduinoEigen/Eigen/src/Core/products/GeneralBlockPanelKernel.h:1270:78: note: in expansion of macro 'D1'
 1270 |           peeled_kc_onestep(1, blA, blB, traits, &A1, &rhs_panel, &T0, &D0, &D1, &D2, &D3);
      |                                                                              ^~
...
```

Please change from `#define` to `const` variable like Seeed Studio ESP32C3.

https://github.com/espressif/arduino-esp32/blob/0d84018d969309addacbcc3e3782c1fadc95fbc8/variants/XIAO_ESP32C3/pins_arduino.h#L30