### PR TITLE
Added support for more PDM frequencies

### DIFF
--- a/libraries/PDM/src/PDM.cpp
+++ b/libraries/PDM/src/PDM.cpp
@@ -91,8 +91,53 @@ int PDMClass::begin(int channels, long sampleRate)
       #endif
       nrf_pdm_clock_set(NRF_PDM, NRF_PDM_FREQ_1280K);
       break;
-    case 41667:
+    case 20000:
+      #ifndef NRF52832_XXAA
+      NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio64 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+      #endif
+      nrf_pdm_clock_set(NRF_PDM, NRF_PDM_FREQ_1280K);
+      break;
+    case 25000:
+      #ifndef NRF52832_XXAA
+      NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio80 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+      #endif
+      nrf_pdm_clock_set(NRF_PDM, NRF_PDM_FREQ_2000K);
+      break;
+    case 31250:
+      #ifndef NRF52832_XXAA
+      NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio64 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+      #endif
+      nrf_pdm_clock_set(NRF_PDM, NRF_PDM_FREQ_2000K);
+      break;
+    case 33333: // Actually 33338
+      #ifndef NRF52832_XXAA
+      NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio80 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+      #endif
       nrf_pdm_clock_set(NRF_PDM, NRF_PDM_FREQ_2667K);
+      break;
+    case 41667: // Actually 41672
+      #ifndef NRF52832_XXAA
+      NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio64 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+      #endif
+      nrf_pdm_clock_set(NRF_PDM, NRF_PDM_FREQ_2667K);
+      break;
+    case 40000:
+      #ifndef NRF52832_XXAA
+      NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio80 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+      #endif
+      nrf_pdm_clock_set(NRF_PDM, NRF_PDM_FREQ_3200K);
+      break;
+    case 50000:
+      #ifndef NRF52832_XXAA
+      NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio64 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+      #endif
+      nrf_pdm_clock_set(NRF_PDM, NRF_PDM_FREQ_3200K);
+      break;
+    case 62500:
+      #ifndef NRF52832_XXAA
+      NRF_PDM->RATIO = ((PDM_RATIO_RATIO_Ratio64 << PDM_RATIO_RATIO_Pos) & PDM_RATIO_RATIO_Msk);
+      #endif
+      nrf_pdm_clock_set(NRF_PDM, NRF_PDM_FREQ_4000K);
       break;
     default:
       return 0; // unsupported


### PR DESCRIPTION
The PDM library to talk to the microphone on the Xiao nRF52840 Sense currently only supported 2 sampling rates: 16 kHz and 41.7 kHz. The hardware actually can support quite a few more and I added the rest of the frequencies according to the [ArduinoPDM](https://github.com/victorromeo/ArduinoPDM) library. I have tested this on the Xiao nRF52840 Sense and it is working on my setup.