### PR TITLE
Allow custom board variants based on this core

### DIFF
--- a/cores/nRF5/main.cpp
+++ b/cores/nRF5/main.cpp
@@ -52,14 +52,7 @@ static void loop_task(void* arg)
   TinyUSB_Device_Init(0);
 #endif
 
-#if defined(ARDUINO_Seeed_XIAO_nRF52840) || defined(ARDUINO_Seeed_XIAO_nRF52840_Sense) || defined(ARDUINO_Seeed_XIAO_nRF52840_Plus) || defined(ARDUINO_Seeed_XIAO_nRF52840_Sense_Plus)
-
-#if CFG_DEBUG 
-  // If Serial is not begin(), call it to avoid hard fault
-  if(!Serial) Serial.begin(115200);
-#endif
-
-#elif defined(ARDUINO_WIO_TRACKER_1110)
+#if defined(ARDUINO_WIO_TRACKER_1110)
 
 #if CFG_LOGGER == 0
   // If Serial is not begin(), call it to avoid hard fault
@@ -81,7 +74,10 @@ static void loop_task(void* arg)
 
 #else
 
-#error "Unsupported board"
+#if CFG_DEBUG
+  // If Serial is not begin(), call it to avoid hard fault
+  if(!Serial) Serial.begin(115200);
+#endif
 
 #endif
 


### PR DESCRIPTION
Adding new boards should be possible without changing the core itself.  The Arduino Platform Specification documents the ability to create custom board variants that reference this core and it would be great if we could do that with the Seeeduino core. Line 84 of main.cpp, unfortunately, makes this impossible.

https://github.com/Seeed-Studio/Adafruit_nRF52_Arduino/blob/master/cores/nRF5/main.cpp#L84:
```
#error "Unsupported board"
```

The suggested change is to restore the default parameters, yet still allow the exceptions (board variants such as the ARDUINO_WIO_TRACKER_1110 that do need to modify the core directly).  There may be better ways to accomplish that exceptional change, but that is not the scope of this pull request

The limited code and changes provided in this pull request are provided freely and completely to the Seeed-Studio project to be used as its maintainers see fit and under any copyright they deem appropriate.