### PR TITLE
Attribute _write function as weak, so it can be overridden by sketch

### DIFF
--- a/cores/nRF5/main.cpp
+++ b/cores/nRF5/main.cpp
@@ -149,7 +149,7 @@ extern "C"
 
 // nanolib printf() retarget
 // Logger 0: Serial (CDC), 1 Serial1 (UART), 2 Segger RTT
-int _write (int fd, const void *buf, size_t count)
+int __attribute__((weak)) _write (int fd, const void *buf, size_t count)
 {
   (void) fd;
 


### PR DESCRIPTION
### Feature request

It would be generally useful if the _write function could be overridden by the sketch. By attributing the function as "weak", this would allow a sketch to override the base functionality to, perhaps, dynamically redirect the console output to another screen, another UART device such as BLEUart, or capture that output into a persisted logfile.